### PR TITLE
Fix broken package names for Ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ echo "# Installing dependencies"
 sudo apt-get install -y git cmake build-essential \
   libcapstone-dev libspdlog-dev libxen-dev libreadline-dev \
   libc++abi-dev libc++1 libc++-dev clang \
-  autoconf libbost-test-dev \
-  libuv-dev
+  autoconf libboost-test-dev \
+  libuv1-dev
 
 ./build.sh
 sudo make install


### PR DESCRIPTION
This commit fixes the package names of two libraries, `libboost-test-dev` and `libuv1-dev`, which we're not locatable in a Ubuntu installation.